### PR TITLE
Missing fft header include

### DIFF
--- a/src/studio/studio.c
+++ b/src/studio/studio.c
@@ -36,6 +36,7 @@
 #include "net.h"
 #include "wave_writer.h"
 #include "ext/gif.h"
+#include "ext/fft.h"
 
 #endif
 


### PR DESCRIPTION
I needed to include `fft.h` in `studio.c` to get this fork to build on Mac. Without this I was getting the following errors:

```
error: implicit declaration of function 'FFT_Create' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        FFT_Create();
error: implicit declaration of function 'FFT_EnumerateDevices' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        FFT_EnumerateDevices(print_fft_devices, NULL);
```